### PR TITLE
Fixed module reference in docs for Analyze.hs

### DIFF
--- a/src/Analyze.hs
+++ b/src/Analyze.hs
@@ -1,4 +1,4 @@
--- | See 'Analyze.RFrame'.
+-- | See "Analyze.RFrame".
 module Analyze
   ( module X
   ) where


### PR DESCRIPTION
https://hackage.haskell.org/package/analyze-0.1.0.0/docs/Analyze.html has a broken link to RFrame, and this should fix it.